### PR TITLE
[codex] Centralize CI tool versions in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "keywords": ["typespec", "openapi", "api"],
   "author": "",
   "license": "MIT",
-  "packageManager": "pnpm@10.8.1"
+  "packageManager": "pnpm@10.8.1",
+  "engines": {
+    "node": "20"
+  }
 }


### PR DESCRIPTION
## Summary

- Move pnpm version selection from GitHub Actions workflow inputs into `package.json` `packageManager` where applicable.
- Move single Node.js CI version selections into `package.json` `engines.node` and have `actions/setup-node` read `node-version-file: package.json`.
- Leave existing major versions and exact versions unchanged; this only centralizes the source of truth.

## Impact

CI keeps using the same pnpm and Node versions, but the versions now live with the project metadata. This makes local tooling and CI easier to compare.

## Validation

- `jq empty` on updated `package.json`
- `git diff --check`
- `actionlint .github/workflows/*.y*ml`
